### PR TITLE
DUPLO-16108 Added Help text  for Add K8s Daemonset Form

### DIFF
--- a/en.json
+++ b/en.json
@@ -130,6 +130,11 @@
                 "ingressLabels": "Key Value pair of labels to be added to SecretProviderClass\nSample Value Can be as bellow\n```yaml\nkey1: value1\nkey2: value2\n```\n",
                 "portOverride": "Select port to override. This field allows to configure frontend listener to use different ports other than 80/443 for http/https."
             },
+            "AddK8sDaemonset": {
+                "Name": "Specify the name of the Daemonset, must be unique",
+                "IsTenantLocal": "When set to true the daemon set will deploy only in hosts within this tenant as against an entire cluster",
+                "Configuration": "Add Daemonset Configurations."
+            },
             "addLambda": {
                 "FunctionName": "Unique name for your Lambda Function.",
                 "Description": "Description of what your Lambda Function does.",

--- a/forms/AddK8sDaemonset.yml
+++ b/forms/AddK8sDaemonset.yml
@@ -1,0 +1,4 @@
+
+Name: "Specify the name of the Daemonset, must be unique"
+IsTenantLocal: "When set to true the daemon set will deploy only in hosts within this tenant as against an entire cluster"
+Configuration: "Add Daemonset Configurations."


### PR DESCRIPTION
## **User description**
DUPLO-16108 Added Help text  for Add K8s Daemonset Form


___

## **Type**
enhancement


___

## **Description**
- Added descriptive help text for the 'Add K8s Daemonset' form to improve user guidance:
  - `Name`: Specify the name of the Daemonset, must be unique.
  - `IsTenantLocal`: When set to true the daemon set will deploy only in hosts within this tenant as against an entire cluster.
  - `Configuration`: Add Daemonset Configurations.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddK8sDaemonset.yml</strong><dd><code>Added Help Text for K8s Daemonset Form Fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
forms/AddK8sDaemonset.yml

<li>Added help text for the 'Add K8s Daemonset' form fields: 'Name', <br>'IsTenantLocal', and 'Configuration'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duplocloud-portal-help/pull/111/files#diff-660a56ec213d52d699cff859a68ead4fa3d7a2af9f8e9669639450662d625df7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

