### PR TITLE
DUPLO-16783 k8s: Fixed Copy-Paste of Yaml  using Help not working

### DIFF
--- a/forms/K8sJobBasicForm.yml
+++ b/forms/K8sJobBasicForm.yml
@@ -12,13 +12,13 @@ restartPolicy: |
 Retries: |
   Set the retry limit. Once the BackoffLimit is reached the Job will be marked as failed.
 envVariables: |
-    Environment variables to be passed to the jobs in the YAML format.
-      ```yaml
-       - Name: VARIABLE1
-         Value: abc.com
-       - Name: VARIABLE2
-         Value: test_value
-      ```
+  Environment variables to be passed to the jobs in the YAML format.
+  ```yaml
+  - Name: VARIABLE1
+    Value: abc.com
+  - Name: VARIABLE2
+    Value: test_value
+  ```
 ContainerName: Specify Name of the Container.
 command: |
   Specify the command attribute for the container.


### PR DESCRIPTION
### **User description**
DUPLO-16783 k8s: Fixed Copy-Paste of Yaml  using Help not working for  'Env Variable' of job & CronJob.

![image](https://github.com/duplocloud/duplocloud-portal-help/assets/129532584/c732a9b1-de35-4b5b-8164-3984fb1ee7b4)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed the copy-paste issue for the YAML example in the `envVariables` section of the K8s Job Basic Form.
- Corrected the indentation and formatting to ensure the YAML example is properly displayed and functional.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>K8sJobBasicForm.yml</strong><dd><code>Fix YAML formatting for environment variables example.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
forms/K8sJobBasicForm.yml

<li>Fixed indentation for the <code>envVariables</code> section.<br> <li> Ensured proper YAML formatting for environment variables example.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/duplocloud-portal-help/pull/118/files#diff-1c77badabd7531254bc6a7c4b6e287be2c72008a2ac4d5e2c6aa59765fe0d9fe">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

